### PR TITLE
Add checks to verify message is not empty before querying OpenAI

### DIFF
--- a/hermeneisGPT.py
+++ b/hermeneisGPT.py
@@ -128,6 +128,7 @@ def translate_mode_automatic(client, config, args):
 
             if not exists_translation:
                 # There is no translation for this message
+                if len(message_text) > 1:
                     count = count+1
 
                     # Message is not empty, translate it with OpenAI model


### PR DESCRIPTION
# Description

Fixes #5 

It adds simple checks to ensure we are not querying OpenAI with empty messages. Messages can be empty, but the prompt is still sent; therefore, the cost of the query remains. If the messages are empty, then do not query at all.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Run py tests manually and all passed
- [x] Run automatic tests through GitHub CI 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
